### PR TITLE
Improve generic dependency injection

### DIFF
--- a/app/Config/Request/Request.php
+++ b/app/Config/Request/Request.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Config\Request;
+
+class Request
+{
+    private string $method;
+    private string $path;
+    private array $query;
+    private array $body;
+    private array $files;
+    private array $headers;
+    private array $routeParams = [];
+
+    public function __construct(?string $rawInput = null)
+    {
+        $this->method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $this->path = explode('?', $_SERVER['REQUEST_URI'])[0] ?? '/';
+        $this->headers = function_exists('getallheaders') ? (getallheaders() ?: []) : [];
+        $this->query = $_GET ?? [];
+        $this->files = $_FILES ?? [];
+        $this->body = $this->parseBody($rawInput);
+    }
+
+    private function parseBody(?string $rawInput = null): array
+    {
+        if (in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
+            $contentType = $this->headers['Content-Type'] ?? $this->headers['content-type'] ?? '';
+            if (str_contains($contentType, 'application/json')) {
+                $raw = $rawInput ?? file_get_contents('php://input');
+                $data = json_decode($raw, true);
+                return is_array($data) ? $data : [];
+            }
+            if ($this->method === 'POST') {
+                return $_POST ?? [];
+            }
+            $raw = $rawInput ?? file_get_contents('php://input');
+            if ($raw !== '') {
+                parse_str($raw, $data);
+                return $data;
+            }
+        }
+        return [];
+    }
+
+    public function setRouteParams(array $params): void
+    {
+        $this->routeParams = $params;
+    }
+
+    public function getRouteParams(): array
+    {
+        return $this->routeParams;
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    public function query(): array
+    {
+        return $this->query;
+    }
+
+    public function body(): array
+    {
+        return $this->body;
+    }
+
+    public function files(): array
+    {
+        return $this->files;
+    }
+
+    public function headers(): array
+    {
+        return $this->headers;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->body[$key] ?? $this->query[$key] ?? $default;
+    }
+}

--- a/app/Config/Response/HttpStatus.php
+++ b/app/Config/Response/HttpStatus.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Config\Response;
+
+enum HttpStatus: int
+{
+    case CONTINUE = 100;
+    case SWITCHING_PROTOCOLS = 101;
+    case PROCESSING = 102;
+    case EARLY_HINTS = 103;
+    case OK = 200;
+    case CREATED = 201;
+    case ACCEPTED = 202;
+    case NON_AUTHORITATIVE_INFORMATION = 203;
+    case NO_CONTENT = 204;
+    case RESET_CONTENT = 205;
+    case PARTIAL_CONTENT = 206;
+    case MULTI_STATUS = 207;
+    case ALREADY_REPORTED = 208;
+    case IM_USED = 226;
+    case MULTIPLE_CHOICES = 300;
+    case MOVED_PERMANENTLY = 301;
+    case FOUND = 302;
+    case SEE_OTHER = 303;
+    case NOT_MODIFIED = 304;
+    case USE_PROXY = 305;
+    case TEMPORARY_REDIRECT = 307;
+    case PERMANENT_REDIRECT = 308;
+    case BAD_REQUEST = 400;
+    case UNAUTHORIZED = 401;
+    case PAYMENT_REQUIRED = 402;
+    case FORBIDDEN = 403;
+    case NOT_FOUND = 404;
+    case METHOD_NOT_ALLOWED = 405;
+    case NOT_ACCEPTABLE = 406;
+    case PROXY_AUTHENTICATION_REQUIRED = 407;
+    case REQUEST_TIMEOUT = 408;
+    case CONFLICT = 409;
+    case GONE = 410;
+    case LENGTH_REQUIRED = 411;
+    case PRECONDITION_FAILED = 412;
+    case PAYLOAD_TOO_LARGE = 413;
+    case URI_TOO_LONG = 414;
+    case UNSUPPORTED_MEDIA_TYPE = 415;
+    case RANGE_NOT_SATISFIABLE = 416;
+    case EXPECTATION_FAILED = 417;
+    case IM_A_TEAPOT = 418;
+    case MISDIRECTED_REQUEST = 421;
+    case UNPROCESSABLE_CONTENT = 422;
+    case LOCKED = 423;
+    case FAILED_DEPENDENCY = 424;
+    case TOO_EARLY = 425;
+    case UPGRADE_REQUIRED = 426;
+    case PRECONDITION_REQUIRED = 428;
+    case TOO_MANY_REQUESTS = 429;
+    case REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+    case UNAVAILABLE_FOR_LEGAL_REASONS = 451;
+    case INTERNAL_SERVER_ERROR = 500;
+    case NOT_IMPLEMENTED = 501;
+    case BAD_GATEWAY = 502;
+    case SERVICE_UNAVAILABLE = 503;
+    case GATEWAY_TIMEOUT = 504;
+    case HTTP_VERSION_NOT_SUPPORTED = 505;
+    case VARIANT_ALSO_NEGOTIATES = 506;
+    case INSUFFICIENT_STORAGE = 507;
+    case LOOP_DETECTED = 508;
+    case NOT_EXTENDED = 510;
+    case NETWORK_AUTHENTICATION_REQUIRED = 511;
+}

--- a/app/Config/Response/Response.php
+++ b/app/Config/Response/Response.php
@@ -2,15 +2,18 @@
 
 namespace App\Config\Response;
 
+use App\Config\Response\HttpStatus;
+
 class Response
 {
-    private int $status = 200;
+    private int $status = HttpStatus::OK->value;
     private array $headers = [];
 
-    public function setStatus(int $status): self
+    public function setStatus(int|HttpStatus $status): self
     {
-        $this->status = $status;
-        http_response_code($status);
+        $code = $status instanceof HttpStatus ? $status->value : $status;
+        $this->status = $code;
+        http_response_code($code);
         return $this;
     }
 
@@ -21,14 +24,14 @@ class Response
         return $this;
     }
 
-    public function json(array $data, int $status = 200): void
+    public function json(array $data, int|HttpStatus $status = HttpStatus::OK): void
     {
         $this->setStatus($status);
         $this->addHeader('Content-Type', 'application/json');
         echo json_encode($data);
     }
 
-    public function send(string $content, int $status = 200): void
+    public function send(string $content, int|HttpStatus $status = HttpStatus::OK): void
     {
         $this->setStatus($status);
         echo $content;

--- a/app/Config/Response/Response.php
+++ b/app/Config/Response/Response.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Config\Response;
+
+class Response
+{
+    private int $status = 200;
+    private array $headers = [];
+
+    public function setStatus(int $status): self
+    {
+        $this->status = $status;
+        http_response_code($status);
+        return $this;
+    }
+
+    public function addHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
+        header("$name: $value", true);
+        return $this;
+    }
+
+    public function json(array $data, int $status = 200): void
+    {
+        $this->setStatus($status);
+        $this->addHeader('Content-Type', 'application/json');
+        echo json_encode($data);
+    }
+
+    public function send(string $content, int $status = 200): void
+    {
+        $this->setStatus($status);
+        echo $content;
+    }
+}

--- a/app/Config/Router/Dispatch.php
+++ b/app/Config/Router/Dispatch.php
@@ -12,7 +12,6 @@ abstract class Dispatch
     protected static ?string $projectUrl = null;
     protected static string $separator;
     protected static ?string $group = null;
-    protected static ?array $data = null;
     protected static ?int $error = null;
 
     public const BAD_REQUEST = 400;
@@ -37,11 +36,6 @@ abstract class Dispatch
         return self::$group = ($group ? str_replace('/', '', $group) : null);
     }
 
-    public function data(): ?array
-    {
-        return self::$data;
-    }
-
     public static function error(): ?int
     {
         return self::$error;
@@ -49,6 +43,9 @@ abstract class Dispatch
 
     public static function run(): bool
     {
+        self::$httpMethod = $_SERVER['REQUEST_METHOD'];
+        self::$patch = explode('?', $_SERVER['REQUEST_URI'])[0];
+
         if (empty(self::$routes) || empty(self::$routes[self::$httpMethod])) {
             self::$error = self::$NOT_IMPLEMENTED;
             return false;
@@ -56,7 +53,7 @@ abstract class Dispatch
 
         self::$route = null;
         foreach (self::$routes[self::$httpMethod] as $key => $route) {
-            if (preg_match('~^' . $key . '$~', self::$patch, $found)) {
+            if (preg_match('~^' . $key . '$~', self::$patch)) {
                 self::$route = $route;
             }
         }
@@ -68,7 +65,8 @@ abstract class Dispatch
     {
         if (self::$route) {
             if (is_callable(self::$route['handler'])) {
-                call_user_func(self::$route['handler'], self::$route['data'] ?? []);
+                $params = make(self::$route['handler'], self::$route['data'] ?? []);
+                call_user_func_array(self::$route['handler'], $params);
                 return true;
             }
 
@@ -78,7 +76,8 @@ abstract class Dispatch
             if (class_exists($controller)) {
                 $newController = new $controller();
                 if (method_exists($controller, $method)) {
-                    $newController->$method((self::$route['data'] ?? []));
+                    $params = make([$newController, $method], self::$route['data'] ?? []);
+                    $newController->$method(...$params);
                     return true;
                 }
 
@@ -94,47 +93,4 @@ abstract class Dispatch
         return false;
     }
 
-    protected static function formSpoofing(): void
-    {
-        $post = filter_input_array(INPUT_POST, FILTER_DEFAULT);
-
-        self::$data = is_array(self::$data) ? self::$data : [];
-        if ($_FILES) {
-            self::$data['files'] = $_FILES;
-        }
-
-        if (!empty($post['_method']) && in_array($post['_method'], ['PUT', 'PATCH', 'DELETE']) && is_array($post)) {
-            self::$httpMethod = $post['_method'];
-            self::$data = array_merge(self::$data, $post);
-
-            unset(self::$data['_method']);
-            return;
-        }
-
-        if (self::$httpMethod == 'POST' && is_array($post)) {
-            self::$data = array_merge(self::$data, $post);
-            return;
-        }
-
-        if (self::$httpMethod == 'GET') {
-            if(!is_array(self::$data)) { self::$data = [];
-            }
-
-            $get = filter_input_array(INPUT_GET, FILTER_DEFAULT);
-            if(!is_array($get)) { return;
-            }
-            self::$data = array_merge(self::$data, $get);
-            return;
-        }
-
-        if (in_array(self::$httpMethod, ['PUT', 'PATCH', 'DELETE']) && !empty($_SERVER['CONTENT_LENGTH'])) {
-            parse_str(file_get_contents('php://input', false, null, 0, $_SERVER['CONTENT_LENGTH']), $putPatch);
-            self::$data = $putPatch;
-
-            unset(self::$data['_method']);
-            return;
-        }
-
-        self::$data = [];
-    }
 }

--- a/app/Config/Router/Dispatch.php
+++ b/app/Config/Router/Dispatch.php
@@ -14,10 +14,10 @@ abstract class Dispatch
     protected static ?string $group = null;
     protected static ?int $error = null;
 
-    public const BAD_REQUEST = 400;
-    public const NOT_FOUND = 404;
-    public const METHOD_NOT_ALLOWED = 405;
-    public const NOT_IMPLEMENTED = 501;
+    public const BAD_REQUEST = \App\Config\Response\HttpStatus::BAD_REQUEST->value;
+    public const NOT_FOUND = \App\Config\Response\HttpStatus::NOT_FOUND->value;
+    public const METHOD_NOT_ALLOWED = \App\Config\Response\HttpStatus::METHOD_NOT_ALLOWED->value;
+    public const NOT_IMPLEMENTED = \App\Config\Response\HttpStatus::NOT_IMPLEMENTED->value;
 
     public function __construct()
     {

--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -65,17 +65,15 @@ class Router extends Dispatch
         $routeDiff = array_values(array_diff(explode('/', parent::$patch), explode('/', $route)));
 
         $offset = parent::$group ? 1 : 0;
-
+        $params = [];
         foreach ($keys as $key) {
-            parent::$data[$key[1]] = $routeDiff[$offset] ?? null;
+            $params[$key[1]] = $routeDiff[$offset] ?? null;
             $offset++;
         }
 
-        parent::formSpoofing();
-
         $route = (!parent::$group ? $route : '/' . parent::$group . "{$route}");
 
-        $data = parent::$data;
+        $data = $params;
 
         $namespace = self::$namespace;
         $router = function () use ($method, $handler, $data, $route, $name, $namespace) {
@@ -88,9 +86,6 @@ class Router extends Dispatch
                 'data' => $data
             ];
         };
-        if (parent::$data) {
-            parent::$data = [];
-        }
 
         $route = preg_replace('~{([^}]*)}~', '([^/]+)', $route);
 

--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -3,6 +3,7 @@
 namespace App\Config\Router;
 
 use Closure;
+use App\Config\Response\HttpStatus;
 
 class Router extends Dispatch
 {
@@ -118,9 +119,14 @@ class Router extends Dispatch
         return null;
     }
 
-    public static function redirect(string $route, $data = null, $status = 301): void
+    public static function redirect(
+        string $route,
+        $data = null,
+        int|HttpStatus $status = HttpStatus::MOVED_PERMANENTLY
+    ): void
     {
-        http_response_code($status);
+        $code = $status instanceof HttpStatus ? $status->value : $status;
+        http_response_code($code);
 
         if ($name = self::route($route, $data)) {
             header("Location: {$name}");

--- a/app/Controllers/HomeController.php
+++ b/app/Controllers/HomeController.php
@@ -6,7 +6,7 @@ use App\Service\PostService;
 
 class HomeController
 {
-    public function home(): void
+    public function home(\App\Config\Request\Request $request): void
     {
             echo "Welcome to the Home Page!\n";
 

--- a/tests/MakeFunctionTest.php
+++ b/tests/MakeFunctionTest.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../app/Config/functions.php';
+
+use PHPUnit\Framework\TestCase;
+use App\Config\Request\Request;
+
+class Dummy {}
+
+class MakeFunctionTest extends TestCase
+{
+    public function testMakeInjectsRequest(): void
+    {
+        $callable = function (Request $r) {
+            // no-op
+        };
+        $params = make($callable, ['id' => 5]);
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(Request::class, $params[0]);
+        $this->assertSame(['id' => 5], $params[0]->getRouteParams());
+    }
+
+    public function testMakeInjectsGenericClass(): void
+    {
+        $callable = function (Dummy $d, Request $r) {};
+
+        $params = make($callable);
+        $this->assertCount(2, $params);
+        $this->assertInstanceOf(Dummy::class, $params[0]);
+        $this->assertInstanceOf(Request::class, $params[1]);
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../app/Config/functions.php';
 use PHPUnit\Framework\TestCase;
 use App\Config\Request\Request;
 use App\Config\Response\Response;
+use App\Config\Response\HttpStatus;
 
 class RequestTest extends TestCase
 {
@@ -47,10 +48,10 @@ class RequestTest extends TestCase
     {
         $response = new Response();
         ob_start();
-        $response->json(['a' => 1], 201);
+        $response->json(['a' => 1], HttpStatus::CREATED);
         $output = ob_get_clean();
 
         $this->assertSame('{"a":1}', $output);
-        $this->assertSame(201, http_response_code());
+        $this->assertSame(HttpStatus::CREATED->value, http_response_code());
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../app/Config/functions.php';
+
+use PHPUnit\Framework\TestCase;
+use App\Config\Request\Request;
+use App\Config\Response\Response;
+
+class RequestTest extends TestCase
+{
+    public function testQueryParameters()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/foo?bar=baz';
+        $_GET = ['bar' => 'baz'];
+
+        $request = new Request();
+        $this->assertSame('GET', $request->method());
+        $this->assertSame('/foo', $request->path());
+        $this->assertSame(['bar' => 'baz'], $request->query());
+        $this->assertSame('baz', $request->get('bar'));
+    }
+
+    public function testJsonBody()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI'] = '/api';
+        $_SERVER['CONTENT_TYPE'] = 'application/json';
+        $json = '{"name":"john"}';
+
+        $request = new Request($json);
+        $this->assertSame(['name' => 'john'], $request->body());
+    }
+
+    public function testFileUpload()
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI'] = '/upload';
+        $_FILES = [
+            'file' => ['name' => 'test.txt']
+        ];
+
+        $request = new Request();
+        $this->assertSame('test.txt', $request->files()['file']['name']);
+    }
+
+    public function testResponseJson()
+    {
+        $response = new Response();
+        ob_start();
+        $response->json(['a' => 1], 201);
+        $output = ob_get_clean();
+
+        $this->assertSame('{"a":1}', $output);
+        $this->assertSame(201, http_response_code());
+    }
+}

--- a/tests/RouterInjectionTest.php
+++ b/tests/RouterInjectionTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace App\Controllers {
+    use App\Config\Request\Request;
+
+    class DummyInjectionController
+    {
+        public static ?Request $captured = null;
+        public function handle(Request $request): void
+        {
+            self::$captured = $request;
+        }
+    }
+}
+
+namespace {
+    require_once __DIR__ . '/../app/Config/functions.php';
+    use PHPUnit\Framework\TestCase;
+    use App\Config\Router\Router;
+    use App\Config\Router\Dispatch;
+    use App\Config\Request\Request;
+    use App\Controllers\DummyInjectionController;
+
+    class RouterInjectionTest extends TestCase
+    {
+        private function setServer(string $method, string $uri): void
+        {
+            $_SERVER['REQUEST_METHOD'] = $method;
+            $_SERVER['REQUEST_URI'] = $uri;
+            $patchProp = new ReflectionProperty(Dispatch::class, 'patch');
+            $patchProp->setAccessible(true);
+            $patchProp->setValue(explode('?', $uri)[0]);
+
+            $methodProp = new ReflectionProperty(Dispatch::class, 'httpMethod');
+            $methodProp->setAccessible(true);
+            $methodProp->setValue($method);
+        }
+
+        private function resetRoutes(): void
+        {
+            foreach ([
+                'routes' => [],
+                'route' => null,
+                'error' => null,
+                'separator' => ':'
+            ] as $name => $value) {
+                $prop = new ReflectionProperty(Dispatch::class, $name);
+                $prop->setAccessible(true);
+                $prop->setValue($value);
+            }
+        }
+
+        protected function setUp(): void
+        {
+            $this->resetRoutes();
+        }
+
+        public function testClosureInjection(): void
+        {
+            $this->setServer('GET', '/inject');
+            $captured = null;
+            Router::get('/inject', function (Request $req) use (&$captured) {
+                $captured = $req;
+            });
+            Router::run();
+            $this->assertInstanceOf(Request::class, $captured);
+        }
+
+        public function testControllerMethodInjection(): void
+        {
+            $this->setServer('GET', '/controller');
+            Router::get('/controller', 'DummyInjectionController:handle');
+            Router::run();
+            $this->assertInstanceOf(Request::class, DummyInjectionController::$captured);
+        }
+
+        public function testRouteParametersAreInjectedIntoRequest(): void
+        {
+            $this->setServer('GET', '/blog/42/test-slug');
+            $captured = null;
+            Router::get('/blog/{id}/{slug}', function (Request $req) use (&$captured) {
+                $captured = $req->getRouteParams();
+            });
+            Router::run();
+            $this->assertSame(['id' => '42', 'slug' => 'test-slug'], $captured);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make helper no longer imports Request class
- make now instantiates any class typed in a callable and sets route params for Request
- extend tests to verify generic injection and route parameter handling

## Testing
- `composer phpcs`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68844372c67c8327b79489064b2688ef