### PR TITLE
Separate CI checks into independent jobs

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  checks:
+  phpcs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,9 +16,39 @@ jobs:
         run: composer update --no-interaction --prefer-dist
       - name: Run PHP CodeSniffer
         run: composer phpcs
+
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
       - name: Run PHPStan
         run: composer phpstan
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
       - name: Audit dependencies
         run: composer audit
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer update --no-interaction --prefer-dist
       - name: Run tests
         run: composer test


### PR DESCRIPTION
## Summary
- split the single workflow job into four separate jobs

## Testing
- `composer phpstan --no-ansi`
- `composer test --no-ansi`
- `composer audit --no-ansi` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884567948c88327ad6a0f7d6f29fb9c