### PR TITLE
Allow setting router controller namespace

### DIFF
--- a/app/Config/Router/Dispatch.php
+++ b/app/Config/Router/Dispatch.php
@@ -73,20 +73,21 @@ abstract class Dispatch
             $controller = self::$route['handler'];
             $method = self::$route['action'];
 
-            if (class_exists($controller)) {
-                $newController = new $controller();
-                if (method_exists($controller, $method)) {
-                    $params = make([$newController, $method], self::$route['data'] ?? []);
-                    $newController->$method(...$params);
-                    return true;
-                }
-
-                self::$error = self::METHOD_NOT_ALLOWED;
-                return false;
+            if (!class_exists($controller)) {
+                self::$error = self::BAD_REQUEST;
+                throw new \RuntimeException("Controller {$controller} not found");
             }
 
-            self::$error = self::BAD_REQUEST;
-            return false;
+            $newController = new $controller();
+
+            if (!method_exists($controller, $method)) {
+                self::$error = self::METHOD_NOT_ALLOWED;
+                throw new \RuntimeException("Method {$method} not found in {$controller}");
+            }
+
+            $params = make([$newController, $method], self::$route['data'] ?? []);
+            $newController->$method(...$params);
+            return true;
         }
 
         self::$error = self::NOT_FOUND;

--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -8,6 +8,10 @@ use App\Config\Response\HttpStatus;
 
 class Router extends Dispatch
 {
+    /**
+     * Base namespace for controllers. Defaults to 'App\Controllers'.
+     * Can be changed using setNamespace().
+     */
     private static string $namespace = 'App\Controllers';
 
     private static string $prefix = '';
@@ -26,6 +30,22 @@ class Router extends Dispatch
     public static function prefix(string $prefix = ''): void
     {
         self::$prefix = $prefix;
+    }
+
+    /**
+     * Change the namespace used to resolve controller classes.
+     */
+    public static function setNamespace(string $namespace): void
+    {
+        self::$namespace = trim($namespace, '\\');
+    }
+
+    /**
+     * Get the current controller namespace.
+     */
+    public static function getNamespace(): string
+    {
+        return self::$namespace;
     }
 
     public static function post($route, $handler, $name = null): void

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,34 @@
 <?php
 
 use App\Config\Router\Router;
+use App\Config\Request\Request;
 
+// Uncomment to prefix all routes with a base path
 // Router::prefix('/api/v1');
-
+// Basic GET route using a controller action
 Router::get('/', 'HomeController:home');
+
+// Route demonstrating path parameters
+Router::get('/blog/{id}/{slug}', 'HomeController:blog');
+
+// Closure route with dependency injection
+Router::get('/hello/{name}', function (Request $request) {
+    $params = $request->getRouteParams();
+    echo "Hello {$params['name']}";
+});
+
+// POST route example
+Router::post('/submit', function () {
+    echo 'Form submitted';
+});
+
+// PUT, PATCH and DELETE examples
+Router::put('/posts/{id}', 'HomeController:update');
+Router::patch('/posts/{id}', 'HomeController:partialUpdate');
+Router::delete('/posts/{id}', 'HomeController:delete');
+
+// Named route example
+Router::get('/contact', 'HomeController:contact', 'contact.page');
 
 Router::run();
 

--- a/tests/RouterExceptionTest.php
+++ b/tests/RouterExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/../app/Config/functions.php';
+
+use PHPUnit\Framework\TestCase;
+use App\Config\Router\Router;
+use App\Config\Router\Dispatch;
+
+class RouterExceptionTest extends TestCase
+{
+    private function setServer(string $method, string $uri): void
+    {
+        $_SERVER['REQUEST_METHOD'] = $method;
+        $_SERVER['REQUEST_URI'] = $uri;
+        $patchProp = new ReflectionProperty(Dispatch::class, 'patch');
+        $patchProp->setAccessible(true);
+        $patchProp->setValue(explode('?', $uri)[0]);
+
+        $methodProp = new ReflectionProperty(Dispatch::class, 'httpMethod');
+        $methodProp->setAccessible(true);
+        $methodProp->setValue($method);
+    }
+
+    private function resetRoutes(): void
+    {
+        foreach ([
+            'routes' => [],
+            'route' => null,
+            'error' => null,
+            'separator' => ':'
+        ] as $name => $value) {
+            $prop = new ReflectionProperty(Dispatch::class, $name);
+            $prop->setAccessible(true);
+            $prop->setValue($value);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->resetRoutes();
+    }
+
+    public function testExceptionForMissingControllerMethod(): void
+    {
+        $this->setServer('GET', '/foo');
+        Router::get('/foo', 'HomeController:missingMethod');
+        $this->expectException(RuntimeException::class);
+        Router::run();
+    }
+}


### PR DESCRIPTION
## Summary
- allow dynamic controller namespace for router
- throw exception on missing controller methods
- expand route examples with comments
- add regression test for exception case

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68845f8a26c0832791d383159d4c4739