### PR TITLE
Add logger configuration and handle debug

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -9,6 +9,9 @@ APP_STAGE=local
 
 APP_DEBUG=true
 
+# Tipo de logger (file ou error_log)
+LOG_DRIVER=file
+
 SAFE_BROWSING_URL=https://safebrowsing.googleapis.com/v4/threatMatches:find
 SAFE_BROWSING_KEY=
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Este projeto fornece uma estrutura inicial simples em PHP para aplicações que 
 
 #### Configurações de ambiente
 
-As variáveis de ambiente estão documentadas em `.env.exemple`. Copie este arquivo para `.env` e ajuste os valores conforme sua necessidade.
+As variáveis de ambiente estão documentadas em `.env.exemple`. Copie este arquivo para `.env` e ajuste os valores conforme sua necessidade. Entre elas, `APP_DEBUG` controla a exibição de erros e `LOG_DRIVER` define o tipo de logger utilizado (`file` ou `error_log`).
 
 #### Rotas de exemplo
 

--- a/app/Config/Log/Log.php
+++ b/app/Config/Log/Log.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Config\Log;
+
+class Log
+{
+    private static string $driver;
+    private static string $filePath;
+    private static bool $initialized = false;
+
+    public static function init(): void
+    {
+        if (self::$initialized) {
+            return;
+        }
+
+        self::$driver = getenv('LOG_DRIVER') ?: 'file';
+        self::$filePath = 'storage/logs/app.log';
+        if (self::$driver === 'file' && !is_dir(dirname(self::$filePath))) {
+            mkdir(dirname(self::$filePath), 0777, true);
+        }
+        self::$initialized = true;
+    }
+
+    public static function info(string $message): void
+    {
+        self::write('INFO', $message);
+    }
+
+    public static function error(string $message): void
+    {
+        self::write('ERROR', $message);
+    }
+
+    private static function write(string $level, string $message): void
+    {
+        self::init();
+        $log = '[' . date('Y-m-d H:i:s') . "] {$level}: {$message}" . PHP_EOL;
+        if (self::$driver === 'error_log') {
+            \error_log($log);
+            return;
+        }
+        file_put_contents(self::$filePath, $log, FILE_APPEND);
+    }
+}

--- a/app/Config/Model/BaseModel.php
+++ b/app/Config/Model/BaseModel.php
@@ -80,7 +80,10 @@ abstract class BaseModel extends Connection
             $stmt->execute($params);
             return parent::$conn->lastInsertId();
         } catch (PDOException $e) {
-            dd($e->getMessage());
+            \App\Config\Log\Log::error($e->getMessage());
+            if (getenv('APP_DEBUG') === 'true') {
+                echo $e->getMessage();
+            }
             return false;
         }
     }

--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -55,11 +55,15 @@ function asset(string $file): string
     return getenv('APP_URL') . '/' . "public" . '/' . "assets" . '/' . "{$file}";
 }
 
-function dd(mixed $data)
+function dd(mixed $data): void
 {
-    echo '<pre>';
-    var_dump($data);
-    die;
+    if (getenv('APP_DEBUG') === 'true') {
+        echo '<pre>';
+        var_dump($data);
+        die;
+    }
+
+    \App\Config\Log\Log::error(is_string($data) ? $data : var_export($data, true));
 }
 
 /**
@@ -68,8 +72,12 @@ function dd(mixed $data)
  */
 function pd(mixed $data): void
 {
-    echo '<pre>', print_r($data, true);
-    die;
+    if (getenv('APP_DEBUG') === 'true') {
+        echo '<pre>', print_r($data, true);
+        die;
+    }
+
+    \App\Config\Log\Log::error(is_string($data) ? $data : var_export($data, true));
 }
 
 /**

--- a/public/index.php
+++ b/public/index.php
@@ -20,7 +20,7 @@ if (getenv('APP_STAGE') === 'PROD') {
     ]);
 }
 
-errorReporting(getenv('APP_DEBUG') === 'true' ? E_ALL : 0);
+errorReporting(getenv('APP_DEBUG') === 'true');
 
 try {
     new Router;
@@ -29,5 +29,8 @@ try {
         captureException($exception);
     }
 
-    dd($exception->getMessage());
+    \App\Config\Log\Log::error($exception->getMessage());
+    if (getenv('APP_DEBUG') === 'true') {
+        echo $exception->getMessage();
+    }
 }


### PR DESCRIPTION
## Summary
- implement `Log` class to manage log outputs
- add `LOG_DRIVER` env to choose between file or error_log
- document new variable in README
- conditionally log in `dd` and `pd` helpers
- replace `dd` calls with logger in BaseModel and index
- fix errorReporting usage

## Testing
- `./vendor/bin/phpcs -p ./app`
- `composer phpstan`
- `composer test`
- `composer audit` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884635103a083279f95989066894500