### PR TITLE
Fix Makefile indentation

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,11 +9,11 @@ up:
 	docker compose up -d
 
 down:
-        docker compose down
+	docker compose down
 
 # Executa todos os testes e analises no container
 ci:
-       docker exec -it app composer phpcs
-       docker exec -it app composer phpstan
-       docker exec -it app composer audit --no-interaction
-       docker exec -it app composer test
+	docker exec -it app composer phpcs
+	docker exec -it app composer phpstan
+	docker exec -it app composer audit --no-interaction
+	docker exec -it app composer test


### PR DESCRIPTION
## Summary
- fix tabs in Makefile to avoid `missing separator` errors

## Testing
- `./vendor/bin/phpcs ./app`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68846cfecae48327b0513941a2e3a564