### PR TITLE
Apply repository improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,10 @@
-node_modules
+.git
+vendor/
+node_modules/
+Dockerfile
+docker-compose.yml
+docker/
+storage/
+tests/
+.env
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Este projeto fornece uma estrutura inicial simples em PHP para aplicações que 
 - MySQL `10`
 - Adminer para gerência do banco de dados
 
+O `BaseModel` usa uma conexão com o banco de dados que é aberta apenas quando
+necessária, evitando conexões antecipadas.
+
 ### Portas dos containers
 
 |Container|Porta|
@@ -25,6 +28,25 @@ Este projeto fornece uma estrutura inicial simples em PHP para aplicações que 
 #### Configurações de ambiente
 
 As variáveis de ambiente estão documentadas em `.env.exemple`. Copie este arquivo para `.env` e ajuste os valores conforme sua necessidade. Entre elas, `APP_DEBUG` controla a exibição de erros e `LOG_DRIVER` define o tipo de logger utilizado (`file` ou `error_log`).
+
+#### Exemplo de roteamento
+
+O roteador oferece uma sintaxe simples para registrar rotas. No arquivo `routes/web.php` você pode declarar rotas apontando para controladores ou funções anônimas:
+
+```php
+use App\Config\Router\Router;
+
+Router::get('/', 'HomeController:home');
+Router::get('/blog/{id}', 'HomeController:blog');
+
+// Agrupando rotas com um prefixo
+Router::prefix('/api');
+Router::get('/status', function () {
+    echo 'API ok';
+});
+```
+
+Para criar novos controladores basta adicioná-los em `app/Controllers` e registrar as rotas correspondentes. Os modelos ficam em `app/Models` e podem herdar de `BaseModel`.
 
 #### Rotas de exemplo
 
@@ -59,3 +81,15 @@ docker/     Imagens e configurações do Docker
 - `composer audit` verifica vulnerabilidades nas dependências.
 - `make cron name=ExempleCron` executa uma tarefa agendada de exemplo.
 - `make ci` roda todas as verificações e testes dentro do container.
+
+### Tarefas agendadas
+
+Tarefas de cron são registradas no arquivo `app/Config/cron.php`. Para executar
+uma delas manualmente utilize:
+
+```sh
+php run-cron.php NomeDaTarefa
+```
+
+O script `cron.sh` é um facilitador que pode ser utilizado em servidores para 
+agendar execuções recorrentes.

--- a/app/Config/Model/BaseModel.php
+++ b/app/Config/Model/BaseModel.php
@@ -57,7 +57,8 @@ abstract class BaseModel extends Connection
     protected static function queryRaw(string $query, array $params = []): array|bool
     {
         try {
-            $stmt = parent::$conn->prepare($query);
+            $conn = parent::getConnection();
+            $stmt = $conn->prepare($query);
             $stmt->execute($params);
             return $stmt->fetchAll(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
@@ -76,9 +77,10 @@ abstract class BaseModel extends Connection
     protected static function save(string $query, array $params): mixed
     {
         try {
-            $stmt = parent::$conn->prepare($query);
+            $conn = parent::getConnection();
+            $stmt = $conn->prepare($query);
             $stmt->execute($params);
-            return parent::$conn->lastInsertId();
+            return $conn->lastInsertId();
         } catch (PDOException $e) {
             \App\Config\Log\Log::error($e->getMessage());
             if (getenv('APP_DEBUG') === 'true') {
@@ -91,7 +93,8 @@ abstract class BaseModel extends Connection
     protected static function execUpdate(string $query, array $params): int
     {
         try {
-            $stmt = parent::$conn->prepare($query);
+            $conn = parent::getConnection();
+            $stmt = $conn->prepare($query);
             $stmt->execute($params);
             return $stmt->rowCount();
         } catch (PDOException $e) {

--- a/app/Config/cron.php
+++ b/app/Config/cron.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'ExempleCron' => App\Config\Cron\ExempleCron::class,
+];

--- a/run-cron.php
+++ b/run-cron.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use App\Config\Cron\CronInterface;
-use App\Config\Cron\ExempleCron;
 
 require_once 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 require_once 'app' . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . 'functions.php';
@@ -12,14 +11,14 @@ $dotenv->load();
 
 if (!isset($argv[1])) {
     echo 'Any task was provided.';
+    exit();
 }
 
 $task = $argv[1];
 
-$cron = match ($task) {
-    'ExempleCron' => new ExempleCron(),
-    default => "Task '{$task}' not found."
-};
+$tasks = require 'app' . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . 'cron.php';
+
+$cron = isset($tasks[$task]) ? new $tasks[$task]() : "Task '{$task}' not found.";
 
 if ($cron instanceof CronInterface) {
 


### PR DESCRIPTION
## Summary
- update documentation with routing examples and cron usage
- expand .dockerignore
- lazily connect to the database on demand
- allow cron tasks to be registered via config

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68846cd58280832790a80365f16a8d50