### PR TITLE
Implement facades for Request and Response

### DIFF
--- a/app/Config/Request/RequestFacade.php
+++ b/app/Config/Request/RequestFacade.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Config\Request;
+
+class RequestFacade
+{
+    public static function __callStatic(string $name, array $arguments): mixed
+    {
+        $instance = new Request();
+        if (!method_exists($instance, $name)) {
+            throw new \BadMethodCallException("Method {$name} not found in " . Request::class);
+        }
+        return $instance->$name(...$arguments);
+    }
+}

--- a/app/Config/Response/ResponseFacade.php
+++ b/app/Config/Response/ResponseFacade.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Config\Response;
+
+class ResponseFacade
+{
+    public static function __callStatic(string $name, array $arguments): mixed
+    {
+        $instance = new Response();
+        if (!method_exists($instance, $name)) {
+            throw new \BadMethodCallException("Method {$name} not found in " . Response::class);
+        }
+        return $instance->$name(...$arguments);
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,7 +3,9 @@ require_once __DIR__ . '/../app/Config/functions.php';
 
 use PHPUnit\Framework\TestCase;
 use App\Config\Request\Request;
+use App\Config\Request\RequestFacade;
 use App\Config\Response\Response;
+use App\Config\Response\ResponseFacade;
 use App\Config\Response\HttpStatus;
 
 class RequestTest extends TestCase
@@ -44,6 +46,16 @@ class RequestTest extends TestCase
         $this->assertSame('test.txt', $request->files()['file']['name']);
     }
 
+    public function testStaticRequestMagicCall(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/static';
+        $_GET = [];
+
+        $this->assertSame('GET', RequestFacade::method());
+        $this->assertSame('/static', RequestFacade::path());
+    }
+
     public function testResponseJson()
     {
         $response = new Response();
@@ -52,6 +64,16 @@ class RequestTest extends TestCase
         $output = ob_get_clean();
 
         $this->assertSame('{"a":1}', $output);
+        $this->assertSame(HttpStatus::CREATED->value, http_response_code());
+    }
+
+    public function testStaticResponseMagicCall(): void
+    {
+        ob_start();
+        ResponseFacade::json(['b' => 2], HttpStatus::CREATED);
+        $output = ob_get_clean();
+
+        $this->assertSame('{"b":2}', $output);
         $this->assertSame(HttpStatus::CREATED->value, http_response_code());
     }
 }


### PR DESCRIPTION
## Summary
- add `RequestFacade` and `ResponseFacade` that forward static method calls using `__callStatic`
- cover new behavior with tests

## Testing
- `php vendor/bin/phpcs -v app`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6884b14c781883278c68fa0687731430