### PR TITLE
Add xdebug in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
 RUN apt-get install libzip-dev libssl-dev pkg-config -y; \
     docker-php-ext-install zip
 RUN pecl install mongodb && docker-php-ext-enable mongodb
+RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 RUN apt-get update; apt-get install curl -y; service apache2 restart;
 


### PR DESCRIPTION
## Summary
- enable xdebug extension in PHP Docker image

## Testing
- `docker compose up -d` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6884d7c4fb648327bf35fed7b0919ed7