### PR TITLE
Fix phpstan memory limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpcbf": [
             "./vendor/bin/phpcbf ./app"
         ],
-        "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon.dist"
+        "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon.dist --memory-limit=512M"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Summary
- bump phpstan memory limit in composer.json scripts so `make ci` doesn't fail

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer test`
- `composer audit` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6884d9e180188327ab9d2e9bade16628