### PR TITLE
Add docblocks for Request and Response facades

### DIFF
--- a/app/Config/Request/RequestFacade.php
+++ b/app/Config/Request/RequestFacade.php
@@ -5,6 +5,20 @@ namespace App\Config\Request;
 
 use BadMethodCallException;
 
+/**
+ * Static proxy to {@see Request} allowing static access to request data.
+ *
+ * @method static void setRouteParams(array $params)
+ * @method static array getRouteParams()
+ * @method static string method()
+ * @method static string path()
+ * @method static array query()
+ * @method static array body()
+ * @method static array files()
+ * @method static array headers()
+ * @method static mixed get(string $key, mixed $default = null)
+ * @method static array validate(array $rules)
+ */
 class RequestFacade
 {
     public static function __callStatic(string $name, array $arguments): mixed

--- a/app/Config/Response/ResponseFacade.php
+++ b/app/Config/Response/ResponseFacade.php
@@ -5,6 +5,17 @@ namespace App\Config\Response;
 
 use BadMethodCallException;
 
+/**
+ * Static proxy to {@see Response} allowing fluent response building.
+ *
+ * @method static self setStatus(int|HttpStatus $status)
+ * @method static self addHeader(string $name, string $value)
+ * @method static void json(array $data, int|HttpStatus $status = HttpStatus::OK)
+ * @method static void view(string $view, array $data = [], int|HttpStatus $status = HttpStatus::OK)
+ * @method static void send(string $content, int|HttpStatus $status = HttpStatus::OK)
+ * @method static int getStatus()
+ * @method static array getHeaders()
+ */
 class ResponseFacade
 {
     public static function __callStatic(string $name, array $arguments): mixed


### PR DESCRIPTION
## Summary
- add PHPDoc comments to `RequestFacade`
- add PHPDoc comments to `ResponseFacade`

## Testing
- `composer phpcs -v`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6884e2413a588327b2a8a232bf4b2a9e