### PR TITLE
Improve Request header fallback

### DIFF
--- a/app/Config/Request/Request.php
+++ b/app/Config/Request/Request.php
@@ -29,7 +29,9 @@ class Request
     private function parseBody(?string $rawInput = null): array
     {
         if (in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
-            $contentType = $this->headers['Content-Type'] ?? $this->headers['content-type'] ?? '';
+            $contentType = $this->headers['Content-Type']
+                ?? $this->headers['content-type']
+                ?? ($_SERVER['CONTENT_TYPE'] ?? ($_SERVER['HTTP_CONTENT_TYPE'] ?? ''));
             if (str_contains($contentType, 'application/json')) {
                 $raw = $rawInput ?? file_get_contents('php://input');
                 $data = json_decode($raw, true);


### PR DESCRIPTION
## Summary
- better parse body when Content-Type header isn't provided by getallheaders

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68854af5f10083279da6b09cb1463c09