### PR TITLE
Support class instantiation via make()

### DIFF
--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -167,10 +167,14 @@ function section(Closure $fun) {
 }
 
 /**
- * Resolve and instantiate class dependencies for a callable.
+ * Resolve and instantiate class dependencies for a callable or a class name.
  */
-function make(callable $callable, array $routeParams = []): array
+function make(callable|string $callable, array $routeParams = []): array|object
 {
+    if (is_string($callable) && class_exists($callable)) {
+        return \App\Config\Container\Container::get($callable);
+    }
+
     $parameters = [];
 
     if (is_array($callable)) {

--- a/tests/MakeFunctionTest.php
+++ b/tests/MakeFunctionTest.php
@@ -35,4 +35,10 @@ class MakeFunctionTest extends TestCase
         $params = make($callable, ['id' => 1, 'slug' => 'a']);
         $this->assertSame([1, 'a'], $params);
     }
+
+    public function testMakeInstantiateClassWithString(): void
+    {
+        $object = make(Dummy::class);
+        $this->assertInstanceOf(Dummy::class, $object);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `make()` helper to also instantiate classes when given a class name
- cover the new functionality with a unit test

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68854b6aa4e883278716f23f4370c8b4