### PR TITLE
Fix missing REDIRECT_URL fallback

### DIFF
--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -198,7 +198,8 @@ class Router extends Dispatch
 
     public static function getUrl($slice = null): array|string
     {
-        $route = explode('/', $_SERVER['REDIRECT_URL']);
+        $url = $_SERVER['REDIRECT_URL'] ?? ($_SERVER['REQUEST_URI'] ?? '/');
+        $route = explode('/', $url);
 
         if ($slice !== null) {
             return $route[$slice] ?? '';

--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -102,8 +102,9 @@ function getPrefixLang(): string
 
 function prefixLang(): string
 {
-    $data = explode('/', $_SERVER['REDIRECT_URL']);
-    return $data[1];
+    $url = $_SERVER['REDIRECT_URL'] ?? ($_SERVER['REQUEST_URI'] ?? '/');
+    $data = explode('/', $url);
+    return $data[1] ?? '';
 }
 
 function getUri(string $uri): string


### PR DESCRIPTION
## Summary
- handle missing `REDIRECT_URL` in helper functions

## Testing
- `composer test`
- `composer phpstan`


------
https://chatgpt.com/codex/tasks/task_e_68854d894084832792699d04bd9af2ec