### PR TITLE
Add referer validation to redirectBack

### DIFF
--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -167,7 +167,19 @@ class Router extends Dispatch
 
     public static function redirectBack(): void
     {
-        header("Location: {$_SERVER['HTTP_REFERER']}");
+        $referer = $_SERVER['HTTP_REFERER'] ?? null;
+        $host = $_SERVER['HTTP_HOST'] ?? parse_url(parent::$projectUrl ?? getenv('APP_URL') ?: '', PHP_URL_HOST);
+
+        if ($referer && filter_var($referer, FILTER_VALIDATE_URL)) {
+            $refererHost = parse_url($referer, PHP_URL_HOST);
+
+            if ($refererHost === $host) {
+                header("Location: {$referer}");
+                exit;
+            }
+        }
+
+        header('Location: /');
         exit;
     }
 


### PR DESCRIPTION
## Summary
- ensure `Router::redirectBack()` only redirects when the `Referer` header is valid and matches the current host
- fall back to `/` when the referer is missing or from another domain

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688676d1062c8327b3e69050137728e0