### PR TITLE
Add secure path validation for views

### DIFF
--- a/app/Config/Response/Response.php
+++ b/app/Config/Response/Response.php
@@ -41,17 +41,28 @@ class Response
     ): void {
         $this->setStatus($status);
 
-        extract($data);
         $fileDir = 'public' . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR;
 
+        if (str_contains($view, '..')) {
+            throw new RuntimeException('invalid view path');
+        }
+
         $filePath = $fileDir . $view . '.php';
+        $baseDir = realpath($fileDir) ?: $fileDir;
+        $realPath = realpath($filePath);
+
+        if ($realPath !== false && !str_starts_with($realPath, $baseDir)) {
+            throw new RuntimeException('invalid view path');
+        }
 
         if (!is_file($filePath)) {
             throw new RuntimeException('view not found');
         }
 
+        extract($data);
+
         ob_start();
-        include $filePath;
+        include $realPath ?: $filePath;
 
         echo ob_get_clean();
     }

--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -9,17 +9,28 @@ CONST LANG_ES = 'es';
 
 function emailView(string $view, array $data = []): mixed
 {
-    extract($data);
     $fileDir = 'public' . DIRECTORY_SEPARATOR . 'email' . DIRECTORY_SEPARATOR;
 
+    if (str_contains($view, '..')) {
+        throw new RuntimeException('invalid view path');
+    }
+
     $filePath = $fileDir . $view . '.php';
+    $baseDir = realpath($fileDir) ?: $fileDir;
+    $realPath = realpath($filePath);
+
+    if ($realPath !== false && !str_starts_with($realPath, $baseDir)) {
+        throw new RuntimeException('invalid view path');
+    }
 
     if (!is_file($filePath)) {
         throw new RuntimeException('view not found');
     }
 
+    extract($data);
+
     ob_start();
-    include $filePath;
+    include $realPath ?: $filePath;
 
     return ob_get_clean();
 }

--- a/tests/ViewSecurityTest.php
+++ b/tests/ViewSecurityTest.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/../app/Config/functions.php';
+
+use PHPUnit\Framework\TestCase;
+use App\Config\Response\Response;
+
+class ViewSecurityTest extends TestCase
+{
+    public function testEmailViewRejectsTraversal(): void
+    {
+        $this->expectException(RuntimeException::class);
+        emailView('../views/home');
+    }
+
+    public function testResponseViewRejectsTraversal(): void
+    {
+        $response = new Response();
+        $this->expectException(RuntimeException::class);
+        $response->view('../views/home');
+    }
+}
+


### PR DESCRIPTION
## Summary
- enforce safe path validation for `emailView()` and `Response::view()`
- add tests covering traversal attempts

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688676d7daa08327bc438e1021203180