### PR TITLE
Escape helper function

### DIFF
--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -33,6 +33,14 @@ function asset(string $file): string
     return getenv('APP_URL') . '/' . "public" . '/' . "assets" . '/' . "{$file}";
 }
 
+/**
+ * Escape output for safe HTML rendering.
+ */
+function e(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
 function dd(mixed $data): void
 {
     if (getenv('APP_DEBUG') === 'true') {


### PR DESCRIPTION
## Summary
- keep `e()` helper for escaping HTML
- revert changes to templates

## Testing
- `./vendor/bin/phpcs ./app -v`
- `composer phpstan`
- `composer audit --no-interaction` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688676d2dce88327922dbdbfecf3064f