### PR TITLE
Refactor Router defaults

### DIFF
--- a/app/Config/Request/Request.php
+++ b/app/Config/Request/Request.php
@@ -16,7 +16,7 @@ class Request
     private array $headers;
     private array $routeParams = [];
 
-    public function __construct(?string $rawInput = null)
+    public function __construct(string $rawInput = '')
     {
         $this->method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
         $this->path = explode('?', $_SERVER['REQUEST_URI'])[0] ?? '/';
@@ -26,26 +26,32 @@ class Request
         $this->body = $this->parseBody($rawInput);
     }
 
-    private function parseBody(?string $rawInput = null): array
+    private function parseBody(string $rawInput = ''): array
     {
+        $input = $rawInput !== '' ? $rawInput : null;
+
         if (in_array($this->method, ['POST', 'PUT', 'PATCH', 'DELETE'])) {
             $contentType = $this->headers['Content-Type']
                 ?? $this->headers['content-type']
                 ?? ($_SERVER['CONTENT_TYPE'] ?? ($_SERVER['HTTP_CONTENT_TYPE'] ?? ''));
+
             if (str_contains($contentType, 'application/json')) {
-                $raw = $rawInput ?? file_get_contents('php://input');
+                $raw = $input ?? file_get_contents('php://input');
                 $data = json_decode($raw, true);
                 return is_array($data) ? $data : [];
             }
+
             if ($this->method === 'POST') {
                 return $_POST;
             }
-            $raw = $rawInput ?? file_get_contents('php://input');
+
+            $raw = $input ?? file_get_contents('php://input');
             if ($raw !== '') {
                 parse_str($raw, $data);
                 return $data;
             }
         }
+
         return [];
     }
 

--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -125,7 +125,7 @@ class Router extends Dispatch
             ?: (explode(parent::$separator, $handler)[1] ? explode(parent::$separator, $handler)[1] : null));
     }
 
-    public static function route($name, $data = null): ?string
+    public static function route($name, array $data = []): ?string
     {
         foreach (static::$routes as $http_verb) {
             foreach ($http_verb as $route_item) {
@@ -142,7 +142,7 @@ class Router extends Dispatch
 
     public static function redirect(
         string $route,
-        $data = null,
+        array $data = [],
         int|HttpStatus $status = HttpStatus::MOVED_PERMANENTLY
     ): void
     {
@@ -183,7 +183,7 @@ class Router extends Dispatch
         exit;
     }
 
-    private static function treat(array $route_item, array $data = null): string
+    private static function treat(array $route_item, array $data = []): string
     {
         $route = $route_item['route'];
 
@@ -202,7 +202,7 @@ class Router extends Dispatch
         return parent::$projectUrl . $route;
     }
 
-    private static function process($route, array $arguments, array $params = null): string
+    private static function process($route, array $arguments, array $params = []): string
     {
         $params = (!empty($params) ? '?' . http_build_query($params) : null);
         return str_replace(array_keys($arguments), array_values($arguments), $route) . "{$params}";


### PR DESCRIPTION
## Summary
- remove null defaults in Router `route`, `redirect`, `treat`, and `process`

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6886985346d0832786042bf33f417828