### PR TITLE
Add missing type hints

### DIFF
--- a/app/Config/Router/Router.php
+++ b/app/Config/Router/Router.php
@@ -48,32 +48,37 @@ class Router extends Dispatch
         return self::$namespace;
     }
 
-    public static function post($route, $handler, $name = null): void
+    public static function post(string $route, callable|string $handler, ?string $name = null): void
     {
         self::addRoute('POST', $route, $handler, $name);
     }
 
-    public static function get($route, $handler, $name = null): void
+    public static function get(string $route, callable|string $handler, ?string $name = null): void
     {
         self::addRoute('GET', $route, $handler, $name);
     }
 
-    public static function put($route, $handler, $name = null): void
+    public static function put(string $route, callable|string $handler, ?string $name = null): void
     {
         self::addRoute('PUT', $route, $handler, $name);
     }
 
-    public static function patch($route, $handler, $name = null): void
+    public static function patch(string $route, callable|string $handler, ?string $name = null): void
     {
         self::addRoute('PATCH', $route, $handler, $name);
     }
 
-    public static function delete($route, $handler, $name = null): void
+    public static function delete(string $route, callable|string $handler, ?string $name = null): void
     {
         self::addRoute('DELETE', $route, $handler, $name);
     }
 
-    protected static function addRoute($method, $route, $handler, $name = null): void
+    protected static function addRoute(
+        string $method,
+        string $route,
+        callable|string $handler,
+        ?string $name = null
+    ): void
     {
         if (self::$prefix !== '') {
             $route = self::$prefix . ($route === '/' ? '' : $route);
@@ -114,18 +119,18 @@ class Router extends Dispatch
         parent::$routes[$method][$route] = $router();
     }
 
-    private static function handler($handler, $namespace): Closure|string
+    private static function handler(callable|string $handler, string $namespace): Closure|string
     {
         return (!is_string($handler) ? $handler : "{$namespace}\\" . explode(parent::$separator, $handler)[0]);
     }
 
-    private static function action($handler): bool|string|null
+    private static function action(callable|string $handler): bool|string|null
     {
         return (!is_string($handler)
             ?: (explode(parent::$separator, $handler)[1] ? explode(parent::$separator, $handler)[1] : null));
     }
 
-    public static function route($name, $data = null): ?string
+    public static function route(string $name, ?array $data = null): ?string
     {
         foreach (static::$routes as $http_verb) {
             foreach ($http_verb as $route_item) {
@@ -142,7 +147,7 @@ class Router extends Dispatch
 
     public static function redirect(
         string $route,
-        $data = null,
+        ?array $data = null,
         int|HttpStatus $status = HttpStatus::MOVED_PERMANENTLY
     ): void
     {
@@ -183,7 +188,7 @@ class Router extends Dispatch
         exit;
     }
 
-    private static function treat(array $route_item, array $data = null): string
+    private static function treat(array $route_item, ?array $data = null): string
     {
         $route = $route_item['route'];
 
@@ -202,13 +207,13 @@ class Router extends Dispatch
         return parent::$projectUrl . $route;
     }
 
-    private static function process($route, array $arguments, array $params = null): string
+    private static function process(string $route, array $arguments, ?array $params = null): string
     {
         $params = (!empty($params) ? '?' . http_build_query($params) : null);
         return str_replace(array_keys($arguments), array_values($arguments), $route) . "{$params}";
     }
 
-    public static function getUrl($slice = null): array|string
+    public static function getUrl(?int $slice = null): array|string
     {
         $url = $_SERVER['REDIRECT_URL'] ?? ($_SERVER['REQUEST_URI'] ?? '/');
         $route = explode('/', $url);

--- a/app/Config/Router/URL.php
+++ b/app/Config/Router/URL.php
@@ -8,15 +8,14 @@ class URL
     private static array $url = [];
     public static array $labelPages = [];
 
-    public static function getLabelPage($url)
+    public static function getLabelPage(string|int $url): mixed
     {
-        return self::$labelPages[$url];
+        return self::$labelPages[$url] ?? null;
     }
 
-    public static function get($positions): string
+    public static function get(int|string ...$positions): string
     {
         self::checkURL();
-        $positions = func_get_args();
 
         if (! count($positions)) {
             return implode('/', self::$url);

--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -178,7 +178,7 @@ function intlFormatDate(string $date): string
 
 }
 
-function section(Closure $fun) {
+function section(Closure $fun): string {
     ob_start();
 
     $fun();

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -8,7 +8,7 @@ use App\Config\Response\HttpStatus;
 
 class RequestTest extends TestCase
 {
-    public function testQueryParameters()
+    public function testQueryParameters(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['REQUEST_URI'] = '/foo?bar=baz';
@@ -21,7 +21,7 @@ class RequestTest extends TestCase
         $this->assertSame('baz', $request->get('bar'));
     }
 
-    public function testJsonBody()
+    public function testJsonBody(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['REQUEST_URI'] = '/api';
@@ -32,7 +32,7 @@ class RequestTest extends TestCase
         $this->assertSame(['name' => 'john'], $request->body());
     }
 
-    public function testFileUpload()
+    public function testFileUpload(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_SERVER['REQUEST_URI'] = '/upload';
@@ -55,7 +55,7 @@ class RequestTest extends TestCase
         $this->assertSame('/static', $request->path());
     }
 
-    public function testResponseJson()
+    public function testResponseJson(): void
     {
         $response = new Response();
         ob_start();


### PR DESCRIPTION
## Summary
- add return type for `section`
- type Router URL utility
- add parameter types for Router methods
- fix tests by typing methods

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68869ce337448327a1cdbae0d541228f