### PR TITLE
fix server null path

### DIFF
--- a/server.php
+++ b/server.php
@@ -1,8 +1,7 @@
 <?php
 
-$uri = urldecode(
-    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
-);
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
+$uri = urldecode($path);
 
 if ($uri !== '/' && file_exists(__DIR__ . '/public' . $uri)) {
     return false;


### PR DESCRIPTION
## Summary
- prevent `urldecode()` warning in `server.php` by defaulting missing path to `/`

## Testing
- `./vendor/bin/phpcs -v ./app`
- `composer phpstan`
- `composer test`
- `composer audit` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886cfaad0fc832795299494786a3931