### PR TITLE
Add start script for project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,9 @@ docker/     Imagens e configurações do Docker
 ### Como instalar
 
 1. Clone este repositório.
-2. Copie `.env.exemple` para `.env` e configure as variáveis.
-3. Execute `docker-compose up -d` para subir os containers.
-4. Caso a pasta `vendor/` não exista, entre no container `app` e rode `composer install`.
-5. A aplicação estará disponível em `http://localhost`.
+2. Execute `./start.sh` para criar o `.env`, ajustar permissões e iniciar os containers.
+3. Caso a pasta `vendor/` não exista, o script executará `composer install` dentro do container `app`.
+4. A aplicação estará disponível em `http://localhost`.
 
 ### Comandos úteis
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Start project using Docker and prepare environment
+# Usage: sh start.sh
+
+set -e
+
+# Create .env from example if it does not exist
+if [ ! -f .env ]; then
+  cp .env.exemple .env
+  echo "Environment file created"
+fi
+
+# Build and run containers in background
+if ! docker compose ps >/dev/null 2>&1; then
+  echo "Docker Compose is not available"
+  exit 1
+fi
+
+docker compose up -d
+
+# Ensure log directory exists with correct permissions
+LOG_DIR="storage/logs"
+mkdir -p "$LOG_DIR"
+chmod -R 775 "$LOG_DIR"
+
+# Install dependencies if vendor directory is missing
+if [ ! -d vendor ]; then
+  docker exec app composer install
+fi
+


### PR DESCRIPTION
## Summary
- add `start.sh` to automate environment setup
- document script usage in README

## Testing
- `composer phpcs` *(no output)*
- `composer phpstan`
- `composer audit` *(failed: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6886d12e482c83278185ae421c7cf76d