### PR TITLE
Remove debug display outside index.php

### DIFF
--- a/app/Config/Database/Connection.php
+++ b/app/Config/Database/Connection.php
@@ -48,9 +48,6 @@ abstract class Connection
             self::$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (PDOException $e) {
             Log::error($e->getMessage(), $e);
-            if (getenv('APP_DEBUG') === 'true') {
-                echo $e->getMessage();
-            }
         }
     }
 
@@ -75,9 +72,6 @@ abstract class Connection
         } catch (PDOException $e) {
             $conn->rollBack();
             Log::error($e->getMessage(), $e);
-            if (getenv('APP_DEBUG') === 'true') {
-                echo $e->getMessage();
-            }
         }
     }
 }

--- a/app/Config/Model/BaseModel.php
+++ b/app/Config/Model/BaseModel.php
@@ -64,9 +64,6 @@ abstract class BaseModel extends Connection
             return $stmt->fetchAll(PDO::FETCH_ASSOC);
         } catch (PDOException $e) {
             Log::error($e->getMessage(), $e);
-            if (getenv('APP_DEBUG') === 'true') {
-                echo $e->getMessage();
-            }
             return false;
         }
     }
@@ -87,9 +84,6 @@ abstract class BaseModel extends Connection
             return $conn->lastInsertId();
         } catch (PDOException $e) {
             Log::error($e->getMessage(), $e);
-            if (getenv('APP_DEBUG') === 'true') {
-                echo $e->getMessage();
-            }
             return false;
         }
     }
@@ -103,9 +97,6 @@ abstract class BaseModel extends Connection
             return $stmt->rowCount();
         } catch (PDOException $e) {
             Log::error($e->getMessage(), $e);
-            if (getenv('APP_DEBUG') === 'true') {
-                echo $e->getMessage();
-            }
             return 0;
         }
     }

--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -54,13 +54,9 @@ function e(string $value): string
 
 function dd(mixed $data): void
 {
-    if (getenv('APP_DEBUG') === 'true') {
-        echo '<pre>';
-        var_dump($data);
-        die;
-    }
-
-    \App\Config\Log\Log::error(is_string($data) ? $data : var_export($data, true));
+    echo '<pre>';
+    var_dump($data);
+    die;
 }
 
 /**
@@ -69,12 +65,8 @@ function dd(mixed $data): void
  */
 function pd(mixed $data): void
 {
-    if (getenv('APP_DEBUG') === 'true') {
-        echo '<pre>', print_r($data, true);
-        die;
-    }
-
-    \App\Config\Log\Log::error(is_string($data) ? $data : var_export($data, true));
+    echo '<pre>', print_r($data, true);
+    die;
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove `APP_DEBUG` message printing from database and model classes
- remove conditional debug checks and logging from helper functions `dd` and `pd`

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6886d6bacc9c8327889b786c1ad50e27