### PR TITLE
Enable interface resolution in dependency container

### DIFF
--- a/app/Config/functions.php
+++ b/app/Config/functions.php
@@ -207,7 +207,7 @@ function make(callable|string $callable, array $routeParams = []): array|object
         $type = $param->getType();
         if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
             $className = $type->getName();
-            if (class_exists($className)) {
+            if (class_exists($className) || interface_exists($className)) {
                 $object = \App\Config\Container\Container::get($className);
                 if ($object instanceof \App\Config\Request\Request) {
                     $object->setRouteParams($routeParams);

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -16,6 +16,9 @@ class ServiceWithDependency
     }
 }
 
+interface SampleInterface {}
+class SampleImplementation implements SampleInterface {}
+
 class ContainerTest extends TestCase
 {
     protected function tearDown(): void
@@ -43,5 +46,12 @@ class ContainerTest extends TestCase
     {
         $object = Container::get(ServiceWithDependency::class);
         $this->assertInstanceOf(Dependency::class, $object->dep);
+    }
+
+    public function testResolveBoundInterface(): void
+    {
+        Container::set(SampleInterface::class, SampleImplementation::class);
+        $params = make(function (SampleInterface $s) {}, []);
+        $this->assertInstanceOf(SampleImplementation::class, $params[0]);
     }
 }


### PR DESCRIPTION
## Summary
- allow `make()` to resolve interfaces by checking `interface_exists`
- verify interface binding through new unit test

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6886e12e3ee08327ad90e292027df07f