### PR TITLE
Remove redundant try-catch from DB classes

### DIFF
--- a/app/Config/Database/Connection.php
+++ b/app/Config/Database/Connection.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 namespace App\Config\Database;
 
 use PDO;
-use PDOException;
-use App\Config\Log\Log;
 /**
  * class Connection
  */
@@ -29,26 +27,22 @@ abstract class Connection
             return;
         }
 
-        try {
-            $db = getenv();
-            $options = [
-                PDO::ATTR_TIMEOUT => 2,
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_general_ci'
-            ];
+        $db = getenv();
+        $options = [
+            PDO::ATTR_TIMEOUT => 2,
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_general_ci'
+        ];
 
-            self::$conn = new PDO(
-                $db['DB_DRIVER'] . ':host=' . $db['DB_HOST'] . ';dbname=' . $db['DB_NAME'] . ';charset=utf8',
-                $db['DB_USER'],
-                $db['DB_PASSWORD'],
-                $options
-            );
+        self::$conn = new PDO(
+            $db['DB_DRIVER'] . ':host=' . $db['DB_HOST'] . ';dbname=' . $db['DB_NAME'] . ';charset=utf8',
+            $db['DB_USER'],
+            $db['DB_PASSWORD'],
+            $options
+        );
 
-            self::$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        } catch (PDOException $e) {
-            Log::error($e->getMessage(), $e);
-        }
+        self::$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
 
     protected static function getConnection(): PDO
@@ -63,15 +57,11 @@ abstract class Connection
     {
         $conn = self::getConnection();
         $conn->beginTransaction();
-        try {
-            $sql = "INSERT into {$table} ({$fields}) VALUES ({$data});";
-            $stmt = $conn->prepare($sql);
-            $stmt->execute($arrayData);
 
-            $conn->commit();
-        } catch (PDOException $e) {
-            $conn->rollBack();
-            Log::error($e->getMessage(), $e);
-        }
+        $sql = "INSERT into {$table} ({$fields}) VALUES ({$data});";
+        $stmt = $conn->prepare($sql);
+        $stmt->execute($arrayData);
+
+        $conn->commit();
     }
 }

--- a/app/Config/Model/BaseModel.php
+++ b/app/Config/Model/BaseModel.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 namespace App\Config\Model;
 
 use App\Config\Database\Connection;
-use App\Config\Log\Log;
 use PDO;
-use PDOException;
 
 /**
  * class BaseModel
@@ -53,19 +51,15 @@ abstract class BaseModel extends Connection
     /**
      * @param string $query
      * @param array $params
-     * @return array|bool
+     * @return array
      */
-    protected static function queryRaw(string $query, array $params = []): array|bool
+    protected static function queryRaw(string $query, array $params = []): array
     {
-        try {
-            $conn = parent::getConnection();
-            $stmt = $conn->prepare($query);
-            $stmt->execute($params);
-            return $stmt->fetchAll(PDO::FETCH_ASSOC);
-        } catch (PDOException $e) {
-            Log::error($e->getMessage(), $e);
-            return false;
-        }
+        $conn = parent::getConnection();
+        $stmt = $conn->prepare($query);
+        $stmt->execute($params);
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     /**
@@ -73,32 +67,24 @@ abstract class BaseModel extends Connection
      *
      * @param string $query
      * @param array $params
-     * @return int|bool
+     * @return string
      */
-    protected static function save(string $query, array $params): mixed
+    protected static function save(string $query, array $params): string
     {
-        try {
-            $conn = parent::getConnection();
-            $stmt = $conn->prepare($query);
-            $stmt->execute($params);
-            return $conn->lastInsertId();
-        } catch (PDOException $e) {
-            Log::error($e->getMessage(), $e);
-            return false;
-        }
+        $conn = parent::getConnection();
+        $stmt = $conn->prepare($query);
+        $stmt->execute($params);
+
+        return $conn->lastInsertId();
     }
 
     protected static function execUpdate(string $query, array $params): int
     {
-        try {
-            $conn = parent::getConnection();
-            $stmt = $conn->prepare($query);
-            $stmt->execute($params);
-            return $stmt->rowCount();
-        } catch (PDOException $e) {
-            Log::error($e->getMessage(), $e);
-            return 0;
-        }
+        $conn = parent::getConnection();
+        $stmt = $conn->prepare($query);
+        $stmt->execute($params);
+
+        return $stmt->rowCount();
     }
 
     /**


### PR DESCRIPTION
## Summary
- simplify `Connection` and `BaseModel` by removing try/catch blocks
- refine `BaseModel` return types

## Testing
- `php vendor/bin/phpcs app --report=checkstyle`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68898c30f45483279c113cfac2d3c089