### PR TITLE
Add tests for app components

### DIFF
--- a/app/Middleware/CorsMiddleware.php
+++ b/app/Middleware/CorsMiddleware.php
@@ -39,7 +39,10 @@ class CorsMiddleware
 
         if ($request->method() === 'OPTIONS') {
             http_response_code(204);
-            exit;
+            if (!defined('APP_TESTING')) {
+                exit;
+            }
+            return;
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,15 @@
          failOnRisky="true"
          cacheDirectory=".phpunit.cache">
 
+    <coverage>
+        <include>
+            <directory>app</directory>
+        </include>
+        <exclude>
+            <directory>app/Config</directory>
+        </exclude>
+    </coverage>
+
     <testsuites>
         <testsuite name="Default">
             <directory suffix="Test.php">tests</directory>

--- a/tests/CorsMiddlewareTest.php
+++ b/tests/CorsMiddlewareTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Middleware\CorsMiddleware;
+use App\Config\Request\Request;
+
+class CorsMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        http_response_code(200);
+        header_remove();
+        if (!defined('APP_TESTING')) {
+            define('APP_TESTING', true);
+        }
+    }
+
+    public function testSetsCorsHeaders(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->any())
+            ->method('method')
+            ->willReturn('GET');
+
+        $middleware = new CorsMiddleware();
+        $middleware($request);
+
+        $this->assertSame(200, http_response_code());
+    }
+
+    public function testOptionsRequestReturnsNoContent(): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->any())
+            ->method('method')
+            ->willReturn('OPTIONS');
+
+        $middleware = new CorsMiddleware();
+        ob_start();
+        $middleware($request);
+        ob_end_clean();
+
+        $this->assertSame(204, http_response_code());
+    }
+}
+

--- a/tests/ExampleModelTest.php
+++ b/tests/ExampleModelTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Model\Example;
+
+class ExampleModelTest extends TestCase
+{
+    public function testAllThrowsWithoutDatabase(): void
+    {
+        putenv('DB_DRIVER=mysql');
+        putenv('DB_HOST=localhost');
+        putenv('DB_NAME=test');
+        putenv('DB_USER=root');
+        putenv('DB_PASSWORD=secret');
+
+        $this->expectException(Throwable::class);
+        (new Example())->all();
+    }
+}
+

--- a/tests/HomeControllerTest.php
+++ b/tests/HomeControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Controller\HomeController;
+use App\Config\Request\Request;
+
+class HomeControllerTest extends TestCase
+{
+    private function requestWith(array $params = []): Request
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->any())
+            ->method('getRouteParams')
+            ->willReturn($params);
+        return $request;
+    }
+
+    public function testHomeOutputsMessage(): void
+    {
+        $controller = new HomeController();
+        ob_start();
+        $controller->home($this->requestWith());
+        $output = ob_get_clean();
+        $this->assertSame("Welcome to the Home Page!\n", $output);
+    }
+
+    public function testBlogOutputsIdAndSlug(): void
+    {
+        $controller = new HomeController();
+        $request = $this->requestWith(['id' => '1', 'slug' => 'post']);
+        ob_start();
+        $controller->blog($request);
+        $output = ob_get_clean();
+        $this->assertSame("Blog post 1 - post\n", $output);
+    }
+
+    public function testUpdateOutputsId(): void
+    {
+        $controller = new HomeController();
+        $request = $this->requestWith(['id' => '2']);
+        ob_start();
+        $controller->update($request);
+        $output = ob_get_clean();
+        $this->assertSame("Updated post 2\n", $output);
+    }
+
+    public function testPartialUpdateOutputsId(): void
+    {
+        $controller = new HomeController();
+        $request = $this->requestWith(['id' => '3']);
+        ob_start();
+        $controller->partialUpdate($request);
+        $output = ob_get_clean();
+        $this->assertSame("Partially updated post 3\n", $output);
+    }
+
+    public function testDeleteOutputsId(): void
+    {
+        $controller = new HomeController();
+        $request = $this->requestWith(['id' => '4']);
+        ob_start();
+        $controller->delete($request);
+        $output = ob_get_clean();
+        $this->assertSame("Deleted post 4\n", $output);
+    }
+
+    public function testContactOutputsMessage(): void
+    {
+        $controller = new HomeController();
+        ob_start();
+        $controller->contact();
+        $output = ob_get_clean();
+        $this->assertSame("Contact page\n", $output);
+    }
+}
+

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Config\Response\Response;
+use App\Config\Response\HttpStatus;
+
+class ResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        http_response_code(200);
+        header_remove();
+    }
+
+    public function testSetStatusAndAddHeader(): void
+    {
+        $response = new Response();
+        $response->setStatus(HttpStatus::CREATED);
+        $response->addHeader('X-Test', '1');
+        $this->assertSame(HttpStatus::CREATED->value, $response->getStatus());
+        $this->assertSame(['X-Test' => '1'], $response->getHeaders());
+    }
+
+    public function testSendOutputsContent(): void
+    {
+        $response = new Response();
+        ob_start();
+        $response->send('Hello', HttpStatus::ACCEPTED);
+        $output = ob_get_clean();
+        $this->assertSame('Hello', $output);
+        $this->assertSame(HttpStatus::ACCEPTED->value, http_response_code());
+    }
+
+    public function testViewRendersTemplate(): void
+    {
+        $viewDir = 'public/views/';
+        $viewName = 'test-view';
+        $viewPath = $viewDir . $viewName . '.php';
+        file_put_contents($viewPath, '<?php echo $msg;');
+
+        $response = new Response();
+        ob_start();
+        $response->view($viewName, ['msg' => 'Hi']);
+        $output = ob_get_clean();
+
+        unlink($viewPath);
+        $this->assertSame('Hi', $output);
+    }
+
+    public function testStaticCallUnknownMethodThrows(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+        Response::unknown();
+    }
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Utils\Utils;
+
+class UtilsTest extends TestCase
+{
+    public function testTraitIsUsable(): void
+    {
+        $obj = new class {
+            use Utils;
+        };
+        $this->assertContains(Utils::class, class_uses($obj));
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure PHPUnit coverage for app directory while excluding Config
- guard CorsMiddleware exit with APP_TESTING constant for testability
- add tests for HomeController, CorsMiddleware, Example model, and Utils trait

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*
- `composer test`
- `composer test -- --coverage-text` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d6287d9883279af9c022f2896d90