### PR TITLE
Remove unnecessary exit statements

### DIFF
--- a/app/Middleware/CorsMiddleware.php
+++ b/app/Middleware/CorsMiddleware.php
@@ -39,7 +39,7 @@ class CorsMiddleware
 
         if ($request->method() === 'OPTIONS') {
             http_response_code(204);
-            exit;
+            return;
         }
     }
 }

--- a/run-cron.php
+++ b/run-cron.php
@@ -26,13 +26,11 @@ $tasks = require 'app' . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . 
 
 $cron = isset($tasks[$task]) ? new $tasks[$task]() : "Task '{$task}' not found.";
 
-if ($cron instanceof CronCronInterface) {
+    if ($cron instanceof CronCronInterface) {
 
-    echo 'Executing task: ' . $task . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
+        echo 'Executing task: ' . $task . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
 
-    $cron->run();
+        $cron->run();
 
-    echo 'Task ' . $task . ' executed successfully' . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
-
-    exit();
-}
+        echo 'Task ' . $task . ' executed successfully' . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
+    }

--- a/run-cron.php
+++ b/run-cron.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-use App\Cron\CronInterface as CronCronInterface;
+use App\Cron\CronInterface;
 use App\Cron\CronRunner;
 use App\Cron\ExampleCron;
 use Dotenv\Dotenv;
@@ -26,11 +26,10 @@ $tasks = require 'app' . DIRECTORY_SEPARATOR . 'Config' . DIRECTORY_SEPARATOR . 
 
 $cron = isset($tasks[$task]) ? new $tasks[$task]() : "Task '{$task}' not found.";
 
-    if ($cron instanceof CronCronInterface) {
+if ($cron instanceof CronInterface) {
+    echo 'Executing task: ' . $task . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
 
-        echo 'Executing task: ' . $task . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
+    $cron->run();
 
-        $cron->run();
-
-        echo 'Task ' . $task . ' executed successfully' . ' - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
-    }
+    echo 'Task ' . $task . ' executed successfully - ' . date('Y-m-d\TH:i:s') . PHP_EOL;
+}


### PR DESCRIPTION
## Summary
- Replace exit with return in CORS middleware
- Drop redundant exit after cron task execution

## Testing
- `composer phpcs && echo phpcs-ok`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a812b9488327b0a1dea9900152bc