### PR TITLE
Handle controller return values through dispatch

### DIFF
--- a/app/Config/Response/Response.php
+++ b/app/Config/Response/Response.php
@@ -11,6 +11,7 @@ class Response
 {
     private int $status = HttpStatus::OK->value;
     private array $headers = [];
+    private string $content = '';
 
     public function setStatus(int|HttpStatus $status): self
     {
@@ -27,18 +28,19 @@ class Response
         return $this;
     }
 
-    public function json(array $data, int|HttpStatus $status = HttpStatus::OK): void
+    public function json(array $data, int|HttpStatus $status = HttpStatus::OK): self
     {
         $this->setStatus($status);
         $this->addHeader('Content-Type', 'application/json');
-        echo json_encode($data);
+        $this->content = json_encode($data);
+        return $this;
     }
 
     public function view(
         string $view,
         array $data = [],
         int|HttpStatus $status = HttpStatus::OK
-    ): void {
+    ): self {
         $this->setStatus($status);
 
         $fileDir = 'public' . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR;
@@ -64,13 +66,19 @@ class Response
         ob_start();
         include $realPath ?: $filePath;
 
-        echo ob_get_clean();
+        $this->content = ob_get_clean();
+        return $this;
     }
 
-    public function send(string $content, int|HttpStatus $status = HttpStatus::OK): void
+    public function send(?string $content = null, int|HttpStatus $status = null): void
     {
-        $this->setStatus($status);
-        echo $content;
+        if ($content !== null) {
+            $this->content = $content;
+        }
+        if ($status !== null) {
+            $this->setStatus($status);
+        }
+        echo $this->content;
     }
 
     public function getStatus(): int

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,5 +52,5 @@ if (Router::error()) {
     (new Response)->json(
         ['error' => 'Not Found'],
         HttpStatus::NOT_FOUND
-    );
+    )->send();
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -59,7 +59,7 @@ class RequestTest extends TestCase
     {
         $response = new Response();
         ob_start();
-        $response->json(['a' => 1], HttpStatus::CREATED);
+        $response->json(['a' => 1], HttpStatus::CREATED)->send();
         $output = ob_get_clean();
 
         $this->assertSame('{"a":1}', $output);
@@ -70,7 +70,7 @@ class RequestTest extends TestCase
     {
         $response = new Response();
         ob_start();
-        $response->json(['b' => 2], HttpStatus::CREATED);
+        $response->json(['b' => 2], HttpStatus::CREATED)->send();
         $output = ob_get_clean();
 
         $this->assertSame('{"b":2}', $output);


### PR DESCRIPTION
## Summary
- allow `Dispatch` to emit controller return values and send `Response`
- refactor `Response` to store content and send on demand
- update error route and tests for new response handling

## Testing
- `composer phpcs`
- `composer phpstan`
- `composer audit` *(fails: CONNECT tunnel failed, response 403)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b4add3ebd4832790b21f8d5609ec02